### PR TITLE
NEW FEATURE: Add background formatoption

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@ v1.2.1
 ======
 Added
 -----
+* a new ``background`` formatoption has been implementat that allows to set the
+  facecolor of the axes (i.e. the background color for the plot)
 * a new ``mask`` formatoption has been implemented that allows to mask the
   data based on a mask that can either be in the dataset or in a separate
   file (see `#15 <https://github.com/psyplot/psy-simple/pull/15>`__)

--- a/psy_simple/base.py
+++ b/psy_simple/base.py
@@ -729,6 +729,39 @@ class Tight(Formatoption):
             plt.tight_layout()
 
 
+class BackgroundColor(Formatoption):
+    """The background color for the matplotlib axes.
+
+    Possible types
+    --------------
+    'rc'
+        to use matplotlibs rc params
+    None
+        to use a transparent color
+    color
+        Any possible matplotlib color
+    """
+
+    group = 'axes'
+
+    name = 'Background color of the plot'
+
+    def update(self, value):
+        if value == 'rc':
+            self.ax.patch.set_facecolor(plt.rcParams['axes.facecolor'])
+            self.ax.set_facecolor(plt.rcParams['axes.facecolor'])
+        elif value is None:
+            self.ax.patch.set_facecolor('none')
+            self.ax.set_facecolor('none')
+        else:
+            self.ax.patch.set_facecolor(value)
+            self.ax.set_facecolor(value)
+
+    def get_fmt_widget(self, parent, project):
+        from psy_simple.widgets.colors import BackGroundColorWidget
+        return BackGroundColorWidget(parent, self, project)
+
+
 class ValueMaskBase(Formatoption):
     """Base class for masking formatoptions"""
     priority = START
@@ -976,6 +1009,7 @@ class BasePlotter(TitlesPlotter):
     _rcparams_string = ['plotter.baseplotter.']
 
     tight = Tight('tight')
+    background = BackgroundColor('background')
     maskless = MaskLess('maskless')
     maskleq = MaskLeq('maskleq')
     maskgreater = MaskGreater('maskgreater')

--- a/psy_simple/plugin.py
+++ b/psy_simple/plugin.py
@@ -863,6 +863,10 @@ rcParams = RcParams(defaultParams={
         'fmt key for the additional properties of the colorbar ticklabels'],
 
     # mask formatoptions
+    'plotter.baseplotter.background': [
+        'rc', try_and_error(ValidateInStrings('background', ['rc']),
+                            validate_none, validate_color),
+        "The background color for the plot"],
     'plotter.baseplotter.mask': [
         None, try_and_error(validate_none, validate_str, validate_dataarray)],
     'plotter.baseplotter.maskleq': [

--- a/psy_simple/widgets/colors.py
+++ b/psy_simple/widgets/colors.py
@@ -386,10 +386,11 @@ class ColorLabel(QtWidgets.QTableWidget):
 
     def setEnabled(self, b):
         if not b:
-            self.orig_color = self.color
+            orig_color = self.color
             self._set_color('0.75')
+            self.color = orig_color
         else:
-            self._set_color(self.orig_color)
+            self._set_color(self.color)
         super().setEnabled(b)
 
     def _set_color(self, color):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -5,6 +5,7 @@ import _base_testing as bt
 import matplotlib as mpl
 import numpy as np
 import matplotlib.pyplot as plt
+import matplotlib.colors as mcol
 import psyplot
 from psy_simple.base import BasePlotter
 from psyplot import InteractiveList, open_dataset
@@ -71,6 +72,11 @@ class BasePlotterTest(bt.PsyPlotTestCase):
         self.assertEqual(get_title().get_size(), 22)
         self.assertEqual(get_title().get_weight(), bold)
         self.assertEqual(get_title().get_ha(), 'left')
+
+    def test_background(self):
+        self.update(background='0.5')
+        bc = mcol.to_rgba(self.plotter.ax.patch.get_facecolor())
+        self.assertEqual(bc, (0.5, 0.5, 0.5, 1.0))
 
     def test_figtitle(self):
         """Test figtitle, figtitlesize, figtitleweight, figtitleprops

--- a/tests/widgets/test_color_widgets.py
+++ b/tests/widgets/test_color_widgets.py
@@ -164,6 +164,39 @@ class BoundsWidgetTest(bt.PsyPlotGuiTestCase):
             fmt_w.get_obj(), np.round(np.linspace(280, 290, 12), 3))
 
 
+class BackgroundColorWidgetTest(bt.PsyPlotGuiTestCase):
+    """Test case for the :class:`BackGroundColorWidget`
+    """
+
+    @property
+    def fmt_widget(self):
+        return self.window.fmt_widget
+
+    @property
+    def plotter(self):
+        return self.project.plotters[0]
+
+    def setUp(self):
+        import psyplot.project as psy
+        super().setUp()
+        self.project = psy.plot.plot2d(
+            self.get_file(osp.join('..', 'test-t2m-u-v.nc')),
+            name='t2m')
+        self.fmt_widget.fmto = self.plotter.background
+
+    def test_transparent(self):
+        w = self.fmt_widget.fmt_widget
+        w.cb_enable.setChecked(True)
+        self.assertIsNone(self.fmt_widget.get_obj())
+        self.assertFalse(w.color_label.isEnabled())
+
+    def test_color_change(self):
+        w = self.fmt_widget.fmt_widget
+        w.color_label.set_color(QtGui.QColor(51, 51, 51, 255))
+        obj = self.fmt_widget.get_obj()
+        self.assertEqual(list(obj), [0.2, 0.2, 0.2, 1.0])
+
+
 class CTicksWidgetTest(bt.PsyPlotGuiTestCase):
     """Test case for the :class:`psy_simple.widgets.colors.BoundsFmtWidget`"""
 


### PR DESCRIPTION
This PR adds the background formatoption to control the
facecolor of the matplotlib axes

 - [x] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes
