### PR TITLE
Do not use matplotlib for testing contains

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,12 +22,12 @@ install:
     - set CONDA_REPO_TOKEN=
     # conda config
     - conda config --set always_yes yes --set changeps1 no
-    - IF NOT DEFINED BUILD_STR_END (conda config --add channels chilipp) ELSE (conda config --add channels conda-forge)
-    - conda config --add channels psyplot
     - conda update -q conda
     - conda install conda-build anaconda-client
     - conda info -a
     - conda list
+    - IF NOT DEFINED BUILD_STR_END (conda config --add channels chilipp) ELSE (conda config --add channels conda-forge)
+    - conda config --add channels psyplot
     # windows config
     - endlocal
     - 'SET PYTHONWARNINGS=ignore:mode:DeprecationWarning:docutils.io:245'

--- a/psy_simple/plotters.py
+++ b/psy_simple/plotters.py
@@ -14,7 +14,6 @@ import matplotlib as mpl
 import matplotlib.axes
 from matplotlib.ticker import FormatStrFormatter, FixedLocator, FixedFormatter
 from matplotlib.dates import DateFormatter, AutoDateFormatter
-from matplotlib.backend_bases import MouseEvent
 import matplotlib.colors as mcol
 import numpy as np
 from psyplot.docstring import docstrings, dedent
@@ -3408,17 +3407,8 @@ class Plot2D(Formatoption):
                         pass
             del self._plot
 
-    def add2format_coord(self, x, y, xorig=None, yorig=None):
+    def add2format_coord(self, x, y):
         """Additional information for the :meth:`format_coord`"""
-        xt, yt = self.ax.transData.transform(
-            [x if xorig is None else xorig, y if yorig is None else yorig])
-        event = MouseEvent('motion_notify_event', self.ax.figure.canvas,
-                           xt, yt)
-        if not self.value is not None or (
-                not self.mappable.contains(event)[0] and
-                (not hasattr(self, '_wrapped_plot') or
-                 not self._wrapped_plot.contains(event)[0])):
-            return ''
         data = self.data
         xcoord = self.xcoord
         ycoord = self.ycoord

--- a/psy_simple/plotters.py
+++ b/psy_simple/plotters.py
@@ -3465,7 +3465,26 @@ class Plot2D(Formatoption):
         dist = np.abs(xy - (x + 1j * y))
         imin = np.nanargmin(dist)
         xy_min = xy[imin]
-        return xy_min.real, xy_min.imag, data.values.ravel()[imin]
+
+        xb = self.decoder.get_cell_node_coord(
+            data, {xcoord.name: xcoord, ycoord.name: ycoord},
+            axis='x')
+        yb = self.decoder.get_cell_node_coord(
+            data, {xcoord.name: xcoord, ycoord.name: ycoord},
+            axis='y')
+
+        dx_max = np.diff(xb).max()
+        dy_max = np.diff(yb).max()
+
+        x_data = xy_min.real
+        y_data = xy_min.imag
+
+        if abs(x_data - x) > dx_max or abs(y_data - y) > dy_max:
+            val = None
+        else:
+            val = data.values.ravel()[imin]
+
+        return x_data, y_data, val
 
 
 docstrings.delete_types('Bounds.possible_types', 'no_norm|None',


### PR DESCRIPTION
Extracting the coordinates using the method from #17 is incredibly low. This PR reverts the changes and instead of using the matplotlib artist to test if it contains the event, we calculate the maximum distance in x and y, and if the distance to the closest grid cell is larger than this maximum dist, we do not use it

 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes
