### PR TITLE
Fix extend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+v1.3.1
+======
+
+Fixed
+-----
+* A bug was fixed with the ``extend`` formatoption if ``plot=None``, see
+  `#20 <https://github.com/psyplot/psy-simple/pull/20>`__
+
 v1.3.0
 ======
 New background and mask formatoptions and more options for colorbar bounds

--- a/psy_simple/plotters.py
+++ b/psy_simple/plotters.py
@@ -3779,7 +3779,8 @@ class Extend(Formatoption):
             warn('[%s] - Extend keyword is not implemented for contour '
                  'plots' % self.logger.name)
         else:
-            self.plot.mappable.norm.extend = value
+            if self.plot.value is not None:
+                self.plot.mappable.norm.extend = value
 
 
 class CbarSpacing(Formatoption):


### PR DESCRIPTION
when the `plot=None`, the new handling of the `extend` formatoption causes issues which is fixed with this PR.

 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes
