### PR TITLE
depreceate tri tricontour and tricontourf

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 v1.3.1
 ======
 
+Changed
+-------
+- the values ``'tri'``, ``'tricontour'`` and ``'tricontourf'`` for the ``plot``
+  formatoptions have been depreceated and should be replaced by ``'poly'``,
+  ``'contour'`` and ``'contourf'`` respectively, see
+  `#23 <https://github.com/psyplot/psy-simple/pull/23>`__
+
 Fixed
 -----
 * A bug was fixed with the ``extend`` formatoption if ``plot=None``, see

--- a/psy_simple/plotters.py
+++ b/psy_simple/plotters.py
@@ -28,8 +28,7 @@ from psyplot.data import (
     InteractiveList, isstring, CFDecoder, _infer_interval_breaks)
 from psyplot.compat.pycompat import map, zip, range
 from psy_simple.plugin import (
-    validate_color, validate_float, safe_list as slist,
-    plot2d_plot_depreceation_map)
+    validate_color, validate_float, safe_list as slist)
 from psyplot.utils import is_iterable
 
 

--- a/psy_simple/plotters.py
+++ b/psy_simple/plotters.py
@@ -28,7 +28,8 @@ from psyplot.data import (
     InteractiveList, isstring, CFDecoder, _infer_interval_breaks)
 from psyplot.compat.pycompat import map, zip, range
 from psy_simple.plugin import (
-    validate_color, validate_float, safe_list as slist)
+    validate_color, validate_float, safe_list as slist,
+    plot2d_plot_depreceation_map)
 from psyplot.utils import is_iterable
 
 
@@ -3182,17 +3183,18 @@ class Plot2D(Formatoption):
     'mesh'
         Use the :func:`matplotlib.pyplot.pcolormesh` function to make the plot
         or the :func:`matplotlib.pyplot.tripcolor` for an unstructered grid
-    'tri'
-        Use the :func:`matplotlib.pyplot.tripcolor` function to plot data on a
-        unstructured grid
+    'poly'
+        Draw each polygon indivually. This method is used by default for
+        unstructured grids. If there are no grid cell boundaries in the
+        dataset, we will interpolate them
     'contourf'
         Make a filled contour plot using the :func:`matplotlib.pyplot.contourf`
         function or the :func:`matplotlib.pyplot.tricontourf` for unstructured
         data. The levels for the contour plot are controlled by the
         :attr:`levels` formatoption
-    'tricontourf'
-        Make a filled contour plot using the
-        :func:`matplotlib.pyplot.tricontourf` function
+    'contour'
+        Same a ``'contourf'``, but does not make a filled contour plot, only
+        lines.
     """
 
     plot_fmt = True
@@ -3258,11 +3260,9 @@ class Plot2D(Formatoption):
         self._plot_funcs = {
             'mesh': self._pcolormesh,
             'contourf': self._contourf,
-            'tricontourf': self._contourf,
             'contour': self._contourf,
-            'tricontour': self._contourf,
-            'tri': self._polycolor,
-            'poly': self._polycolor}
+            'poly': self._polycolor,
+        }
         self._orig_format_coord = None
         self._kwargs = {}
 

--- a/psy_simple/plugin.py
+++ b/psy_simple/plugin.py
@@ -686,6 +686,20 @@ class LineWidthValidator(ValidateInStrings):
             return np.asarray(val, float)
 
 
+def validate_plot(val):
+    val = ValidateInStrings('2d plot', ['mesh', 'contourf', 'contour', 'poly',
+                            'tri', 'tricontourf', 'tricontour'], True)
+    depr_map = {
+        "tri": "poly", "tricontourf": "contourf", "tricontour": "contour"
+    }
+    if val in depr_map:
+        warn("plot=%r is depreceated for the plot formatoption and will be "
+             "removed in psy-simple 1.4.0. Please use plot=%r instead." % (
+                 val, depr_map[val]))
+        return depr_map[val]
+    return val
+
+
 # -----------------------------------------------------------------------------
 # ------------------------------ rcParams -------------------------------------
 # -----------------------------------------------------------------------------
@@ -1019,9 +1033,7 @@ rcParams = RcParams(defaultParams={
         None, validate_bool_maybe_none,
         'Switch to interpolate the bounds for 2D plots'],
     'plotter.plot2d.plot': [
-        'mesh', try_and_error(validate_none, ValidateInStrings(
-            '2d plot', ['mesh', 'contourf', 'contour', 'poly',
-                        'tri', 'tricontourf', 'tricontour'], True)),
+        'mesh', try_and_error(validate_none, validate_plot),
         'fmt key to specify the plot type of 2D scalar plots'],
     'plotter.plot2d.plot.min_circle_ratio': [
         0.05, validate_float,
@@ -1138,3 +1150,6 @@ del _key, _subd
 
 
 rcParams.update_from_defaultParams()
+
+
+rcParams.dep

--- a/psy_simple/plugin.py
+++ b/psy_simple/plugin.py
@@ -687,15 +687,19 @@ class LineWidthValidator(ValidateInStrings):
 
 
 def validate_plot(val):
-    val = ValidateInStrings('2d plot', ['mesh', 'contourf', 'contour', 'poly',
-                            'tri', 'tricontourf', 'tricontour'], True)
+    validator = ValidateInStrings(
+        '2d plot', ['mesh', 'contourf', 'contour', 'poly',
+                    'tri', 'tricontourf', 'tricontour'], True)
+
+    val = validator(val)
     depr_map = {
         "tri": "poly", "tricontourf": "contourf", "tricontour": "contour"
     }
     if val in depr_map:
         warn("plot=%r is depreceated for the plot formatoption and will be "
              "removed in psy-simple 1.4.0. Please use plot=%r instead." % (
-                 val, depr_map[val]))
+                 val, depr_map[val]),
+             DeprecationWarning)
         return depr_map[val]
     return val
 
@@ -1150,6 +1154,3 @@ del _key, _subd
 
 
 rcParams.update_from_defaultParams()
-
-
-rcParams.dep

--- a/tests/test_plotters.py
+++ b/tests/test_plotters.py
@@ -2371,5 +2371,19 @@ for cls in tests2d:
 del cls
 
 
+@pytest.mark.parametrize(
+    "old,new",
+    (("tri", "poly"), ("tricontour", "contour"), ("tricontourf", "contourf")),
+    )
+def test_plot_deprecation(old, new):
+    """Test if tri is deprecated correctly"""
+    with psy.open_dataset(os.path.join(bt.test_dir, "icon_test.nc")) as ds:
+        with pytest.warns(DeprecationWarning, match="plot=[\"']%s[\"']" % old):
+            sp = ds.psy.plot.mapplot(name="t2m", plot=old)
+    plotter = sp.plotters[0]
+    assert plotter.plot.value == new
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_plotters.py
+++ b/tests/test_plotters.py
@@ -2379,7 +2379,7 @@ def test_plot_deprecation(old, new):
     """Test if tri is deprecated correctly"""
     with psy.open_dataset(os.path.join(bt.test_dir, "icon_test.nc")) as ds:
         with pytest.warns(DeprecationWarning, match="plot=[\"']%s[\"']" % old):
-            sp = ds.psy.plot.mapplot(name="t2m", plot=old)
+            sp = ds.psy.plot.plot2d(name="t2m", plot=old)
     plotter = sp.plotters[0]
     assert plotter.plot.value == new
 


### PR DESCRIPTION
It was mapped anyway to `poly`, `contour` or `contourf` and we use the correct method depending on whether it is unstructured or not.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes
